### PR TITLE
feat: changes author to Mollie

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "prettier --write ./src ./tests ./config ./**/*.md"
   },
   "keywords": [],
-  "author": "AND Digital",
+  "author": "Mollie",
   "license": "MIT",
   "devDependencies": {
     "@types/express": "^4.17.13",

--- a/notifications/package.json
+++ b/notifications/package.json
@@ -16,7 +16,7 @@
     "lint:fix": "prettier --write ./src ./tests ./config ./**/*.md"
   },
   "keywords": [],
-  "author": "AND Digital",
+  "author": "Mollie",
   "license": "MIT",
   "devDependencies": {
     "@types/express": "^4.17.13",


### PR DESCRIPTION
As per chat on Slack, updating our repo to have `"author": "Mollie"` instead of AND Digital. 