### PR TITLE
test: add tests for processAction

### DIFF
--- a/extension/src/requestHandlers/handleRequest.ts
+++ b/extension/src/requestHandlers/handleRequest.ts
@@ -38,7 +38,7 @@ export default async function handleRequest(req: Request, res: Response) {
     }
   } catch (error: any) {
     // TODO - check this does not expose PII in stacktrace
-    Logger.warn(error);
+    Logger.error({ error });
     // From Node's Error object: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
     const errorMessage = `error_name: ${error.name}, error_message: ${error.message}`;
     return res.status(400).send({

--- a/extension/tests/requestHandlers/handleRequest.test.ts
+++ b/extension/tests/requestHandlers/handleRequest.test.ts
@@ -1,4 +1,4 @@
-import createMollieClient, { MollieClient } from '@mollie/api-client';
+import { MollieClient } from '@mollie/api-client';
 import { Request, Response } from 'express';
 import { mocked } from 'ts-jest/utils';
 import actions, { validateAction } from '../../src/requestHandlers/actions';
@@ -15,7 +15,7 @@ describe('handleRequest', () => {
   const mockStatus = jest.fn().mockReturnValue(res);
   const mockSend = jest.fn().mockReturnValue(res);
   const mockEnd = jest.fn();
-  const mockLogWarn = jest.fn();
+  const mockLogError = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -24,7 +24,7 @@ describe('handleRequest', () => {
     res.send = mockSend;
     res.end = mockEnd;
     req.path = '/';
-    Logger.warn = mockLogWarn;
+    Logger.error = mockLogError;
   });
 
   afterAll(() => {
@@ -100,7 +100,7 @@ describe('handleRequest', () => {
         },
       ],
     });
-    expect(mockLogWarn).toHaveBeenCalledTimes(1);
+    expect(mockLogError).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Ticket: https://anddigitaltransformation.atlassian.net/browse/CMI-75
## Description

Add tests for processAction. This increases the test coverage for request handler to 100%

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

No special test configuration, run `npm run test -- --coverage`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation where necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works/doesn't break everything
- [x] Existing tests pass locally with my changes
