### PR TITLE
Fix coverage collection on Jest

### DIFF
--- a/extension/tests/jest.config.js
+++ b/extension/tests/jest.config.js
@@ -1,8 +1,9 @@
 module.exports = {
-  roots: ['<rootDir>'],
+  rootDir: '../.',
+  roots: ['<rootDir>/tests'],
   testMatch: ['**/?(*.)+(test).+(ts|js)'],
   transform: {
     '^.+\\.(ts)$': 'ts-jest',
   },
-  setupFiles: ['<rootDir>/setEnvVars.js'],
+  setupFiles: ['<rootDir>/tests/setEnvVars.js'],
 };


### PR DESCRIPTION

## Description

When I moved the test folder structure, I broke coverage. 

This PR updates the rootDir in the jest config. The coverage wasn't being collected before as Jest didn't know where to look. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

Checkout `develop`. Run `npm run test -- --collectCoverage` to see the error. The coverage is supposedly collected, but it's 0% across 0 files. 

Checkout this branch.`. Run `npm run test -- --collectCoverage` to see the coverage.
Open the file in browser with `open coverage/lcov-report/index.html`

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation where necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works/doesn't break everything
- [x] Existing tests pass locally with my changes
