### PR TITLE
Feat/cmi 116 swap validateaction for determineaction

### DIFF
--- a/extension/src/errorHandlers/formatExtensionErrorResponse.ts
+++ b/extension/src/errorHandlers/formatExtensionErrorResponse.ts
@@ -1,0 +1,24 @@
+import { CTEnumErrors, CTError } from '../types';
+
+/**
+ *
+ * @param code Defaults to "General" if not provided
+ * @param message High level description of the error
+ * @param extraInfo JSON object, optional
+ */
+export const formatExtensionErrorResponse = (code: CTEnumErrors = CTEnumErrors.General, message: string, extraInfo?: Object) => {
+  const errorMessage = !!message ? message : 'Error, see logs for more details';
+  const formattedError: CTError = {
+    code,
+    message: errorMessage,
+  };
+
+  if (extraInfo && Object.keys(extraInfo).length) {
+    formattedError['extensionExtraInfo'] = extraInfo;
+  }
+
+  return {
+    status: 400,
+    errors: [formattedError],
+  };
+};

--- a/extension/src/errorHandlers/formatMollieErrorResponse.ts
+++ b/extension/src/errorHandlers/formatMollieErrorResponse.ts
@@ -1,4 +1,4 @@
-import { CTError, CTUpdatesRequestedResponse } from '../types';
+import { CTError, CTUpdatesRequestedResponse, CTEnumErrors } from '../types';
 
 // This is based on MollieApiError interface from Mollie's SDK
 const getExtraInfo = (error: any) => {
@@ -24,7 +24,7 @@ export const formatMollieErrorResponse = (error: any): CTUpdatesRequestedRespons
     case status === 401:
     case status === 403:
       formattedError = {
-        code: 'Unauthorized',
+        code: CTEnumErrors.Unauthorized,
         message: 'Forbidden or Unauthorized - Request to Mollie API failed',
         extensionExtraInfo: getExtraInfo(error),
       };
@@ -32,7 +32,7 @@ export const formatMollieErrorResponse = (error: any): CTUpdatesRequestedRespons
 
     case status === 400:
       formattedError = {
-        code: 'SyntaxError',
+        code: CTEnumErrors.SyntaxError,
         message: 'Request formatted incorrectly or missing information',
         extensionExtraInfo: getExtraInfo(error),
       };
@@ -40,7 +40,7 @@ export const formatMollieErrorResponse = (error: any): CTUpdatesRequestedRespons
 
     case status === 422:
       formattedError = {
-        code: 'SemanticError',
+        code: CTEnumErrors.SemanticError,
         message: error.message,
         extensionExtraInfo: getExtraInfo(error),
       };
@@ -48,7 +48,7 @@ export const formatMollieErrorResponse = (error: any): CTUpdatesRequestedRespons
 
     case status === 404:
       formattedError = {
-        code: 'ObjectNotFound',
+        code: CTEnumErrors.ObjectNotFound,
         message: error.message,
         extensionExtraInfo: getExtraInfo(error),
       };
@@ -56,7 +56,7 @@ export const formatMollieErrorResponse = (error: any): CTUpdatesRequestedRespons
 
     case status === 409:
       formattedError = {
-        code: 'InvalidOperation',
+        code: CTEnumErrors.InvalidOperation,
         message: error.message,
         extensionExtraInfo: getExtraInfo(error),
       };
@@ -64,7 +64,7 @@ export const formatMollieErrorResponse = (error: any): CTUpdatesRequestedRespons
 
     case status >= 400 && status < 500:
       formattedError = {
-        code: 'SyntaxError',
+        code: CTEnumErrors.SyntaxError,
         message: `Request error - ${error.status} code returned from Mollie`,
         extensionExtraInfo: getExtraInfo(error),
       };
@@ -72,7 +72,7 @@ export const formatMollieErrorResponse = (error: any): CTUpdatesRequestedRespons
     default:
       //5xx
       formattedError = {
-        code: 'General',
+        code: CTEnumErrors.General,
         message: 'Server Error. Please see logs for more details',
         extensionExtraInfo: getExtraInfo(error),
       };

--- a/extension/src/types/index.ts
+++ b/extension/src/types/index.ts
@@ -1,3 +1,15 @@
+// This is not exhaustive
+// If you use another commercetools error response code, add it to this enum
+export enum CTEnumErrors {
+  General = 'General',
+  InvalidInput = 'InvalidInput',
+  InvalidOperation = 'InvalidOperation',
+  Unauthorized = 'Unauthorized',
+  SyntaxError = 'SyntaxError',
+  SemanticError = 'SemanticError',
+  ObjectNotFound = 'ObjectNotFound',
+}
+
 export type CTUpdatesRequestedResponse = {
   status: number;
   actions?: Action[];
@@ -24,7 +36,7 @@ export type Action = {
 };
 
 export type CTError = {
-  code: string;
+  code: CTEnumErrors;
   message: string;
   extensionExtraInfo?: Object;
 };

--- a/extension/tests/unit/errorHandlers/formatExtensionErrorResponse.test.ts
+++ b/extension/tests/unit/errorHandlers/formatExtensionErrorResponse.test.ts
@@ -1,0 +1,31 @@
+import { CTEnumErrors } from '../../../src/types/index';
+import { formatExtensionErrorResponse } from '../../../src/errorHandlers/formatExtensionErrorResponse';
+
+describe('formatExtensionErrorResponse', () => {
+  it('should return the formatted error array when provided a code and message', () => {
+    const { errors } = formatExtensionErrorResponse(CTEnumErrors.SyntaxError, 'Payment not processable');
+    expect(errors[0]).toEqual({
+      code: 'SyntaxError',
+      message: 'Payment not processable',
+    });
+  });
+
+  it('should return default code and message if these are not provided', () => {
+    const { errors } = formatExtensionErrorResponse(undefined, '');
+    expect(errors[0]).toEqual({
+      code: 'General',
+      message: 'Error, see logs for more details',
+    });
+  });
+
+  it('should return the formatted error and extra information if this object is provided', () => {
+    const { errors } = formatExtensionErrorResponse(CTEnumErrors.InvalidInput, 'Cannot process payment', { field: 'custom.fields.paymentMethodsRequest' });
+    expect(errors[0]).toEqual({
+      code: 'InvalidInput',
+      message: 'Cannot process payment',
+      extensionExtraInfo: {
+        field: 'custom.fields.paymentMethodsRequest',
+      },
+    });
+  });
+});

--- a/extension/tests/unit/requestHandlers/handleRequest.test.ts
+++ b/extension/tests/unit/requestHandlers/handleRequest.test.ts
@@ -4,12 +4,14 @@ import { mocked } from 'ts-jest/utils';
 import actions from '../../../src/requestHandlers/actions';
 import handleRequest, { processAction } from '../../../src/requestHandlers/handleRequest';
 import { determineAction } from '../../../src/requestHandlers/determineAction/determineAction';
-import { ControllerAction } from '../../../src/types/index';
+import { formatExtensionErrorResponse } from '../../../src/errorHandlers/formatExtensionErrorResponse';
+import { ControllerAction, CTEnumErrors } from '../../../src/types/index';
 import * as ut from '../../../src/utils';
 import Logger from '../../../src/logger/logger';
 
 jest.mock('../../../src/requestHandlers/actions');
 jest.mock('../../../src/requestHandlers/determineAction/determineAction');
+jest.mock('../../../src/errorHandlers/formatExtensionErrorResponse');
 jest.mock('../../../src/utils');
 
 describe('handleRequest', () => {
@@ -89,6 +91,15 @@ describe('handleRequest', () => {
       action: ControllerAction.NoAction,
       errorMessage: 'Invalid paymentMethodInfo.method cash. Payment method must be set in order to make and manage payment transactions',
     });
+    mocked(formatExtensionErrorResponse).mockReturnValueOnce({
+      status: 400,
+      errors: [
+        {
+          code: CTEnumErrors.InvalidInput,
+          message: 'Invalid paymentMethodInfo.method cash. Payment method must be set in order to make and manage payment transactions',
+        },
+      ],
+    });
 
     await handleRequest(req, res);
 
@@ -110,7 +121,7 @@ describe('handleRequest', () => {
       status: 400,
       errors: [
         {
-          code: 'Unauthorized',
+          code: CTEnumErrors.Unauthorized,
           message: 'API Key error',
         },
       ],
@@ -122,7 +133,7 @@ describe('handleRequest', () => {
     expect(mockSend).toHaveBeenCalledWith({
       errors: [
         {
-          code: 'Unauthorized',
+          code: CTEnumErrors.Unauthorized,
           message: 'API Key error',
         },
       ],
@@ -141,7 +152,7 @@ describe('handleRequest', () => {
     expect(mockSend).toHaveBeenCalledWith({
       errors: [
         {
-          code: 'General',
+          code: CTEnumErrors.General,
           message: 'error_name: Big error, error_message: Something went wrong',
         },
       ],


### PR DESCRIPTION
## Description

Ticket: https://anddigitaltransformation.atlassian.net/browse/CMI-116
Part 2 of ~3

This PR swaps the `validateAction` method for `determineAction`. 

It also introduces an error formatter for the API extension. This should be used when the API extension is returning the error before it has called mollie, or handling very general error scenarios. This uses a (non-exhaustive) list of CT Error Enums.

⚠️ **PLEASE NOTE**
- this PR doesn't change the order of the checks in `handleRequest`, that is being covered by #47 
- this PR introduces the shared method I asked for in #45 - @sandriches let's check together and make sure it's something we can both use 😄  

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

I need to deploy this and check the new changes return as expected from no action, error states. 

Need to trigger the other actions to check they can be still triggered, though they may error further on as we are refactoring those functions.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation where necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works/doesn't break everything
- [x] Existing tests pass locally with my changes
