### PR TITLE
fix: bump node-fetch version

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -9,46 +9,45 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@azure/functions": "^1.2.3",
-        "@commercetools/platform-sdk": "^1.20.0",
-        "@commercetools/sdk-client": "^2.1.2",
-        "@commercetools/sdk-middleware-auth": "^6.1.4",
-        "@commercetools/sdk-middleware-http": "^6.0.11",
-        "@commercetools/sdk-middleware-user-agent": "^2.1.5",
+        "@azure/functions": "3.0.0",
+        "@commercetools/platform-sdk": "2.1.0",
+        "@commercetools/sdk-client": "2.1.2",
+        "@commercetools/sdk-middleware-auth": "6.2.0",
+        "@commercetools/sdk-middleware-http": "6.1.0",
+        "@commercetools/sdk-middleware-user-agent": "2.1.5",
         "@mollie/api-client": "3.6.0-beta.3",
-        "dotenv": "^11.0.0",
-        "express": "^4.17.1",
-        "lodash": "^4.17.21",
-        "morgan": "^1.10.0",
-        "node-fetch-commonjs": "^3.1.1",
-        "uuid": "^8.3.2",
+        "express": "4.17.2",
+        "lodash": "4.17.21",
+        "morgan": "1.10.0",
+        "node-fetch-commonjs": "3.1.1",
+        "uuid": "8.3.2",
         "winston": "3.4.0"
       },
       "devDependencies": {
-        "@types/aws-lambda": "^8.10.88",
-        "@types/express": "^4.17.13",
-        "@types/jest": "^27.0.3",
-        "@types/lodash": "^4.14.175",
-        "@types/morgan": "^1.9.3",
+        "@types/aws-lambda": "8.10.89",
+        "@types/express": "4.17.13",
+        "@types/jest": "27.4.0",
+        "@types/lodash": "4.14.178",
+        "@types/morgan": "1.9.3",
         "@types/node": "14.18.5",
-        "@types/supertest": "^2.0.11",
-        "@types/uuid": "^8.3.3",
-        "axios": "^0.24.0",
-        "jest": "^27.2.1",
-        "nock": "^13.2.1",
-        "node-mocks-http": "^1.11.0",
-        "nodemon": "^2.0.12",
-        "prettier": "^2.4.1",
-        "supertest": "^6.1.6",
-        "ts-jest": "^27.0.5",
-        "ts-node": "^10.2.1",
-        "typescript": "^4.4.3"
+        "@types/supertest": "2.0.11",
+        "@types/uuid": "8.3.4",
+        "axios": "0.24.0",
+        "jest": "27.4.7",
+        "nock": "13.2.2",
+        "node-mocks-http": "1.11.0",
+        "nodemon": "2.0.15",
+        "prettier": "2.5.1",
+        "supertest": "6.2.1",
+        "ts-jest": "27.1.2",
+        "ts-node": "10.4.0",
+        "typescript": "4.5.4"
       }
     },
     "node_modules/@azure/functions": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-1.2.3.tgz",
-      "integrity": "sha512-dZITbYPNg6ay6ngcCOjRUh1wDhlFITS0zIkqplyH5KfKEAVPooaoaye5mUFnR+WP9WdGRjlNXyl/y2tgWKHcRg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-3.0.0.tgz",
+      "integrity": "sha512-nxOdQdYoy9JEdAPsQlBWavsRvbH5qT2fpwMcY64s1sLIT8QwtW7ebh/MJNgzeAac+JaC6IED7plDiizq8oZUNw=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",
@@ -662,11 +661,11 @@
       "integrity": "sha512-d6migEVDtJ/BlKAkpGj4HZvUSBmKwCIX6L8iRRlMNbbBLjpN3oWqOi5nRsO3v21bS8LHBBVYoFWrBtWKbqLeVQ=="
     },
     "node_modules/@commercetools/platform-sdk": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@commercetools/platform-sdk/-/platform-sdk-1.20.0.tgz",
-      "integrity": "sha512-vjorTz9yZ0wh8MRgncqjeJstREIaOA2glGR/ZjmJvLNpxksE0h2FKNA+/T6K7k2YzdjnNgWE6FKh/FU1TaiGRA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/platform-sdk/-/platform-sdk-2.1.0.tgz",
+      "integrity": "sha512-QhfTkU8tuO8buYbHmGOSZuWE7kObHlx0dZsKwCYyVJeplFThmb1ni7f1CfK7PNbPWoRO9k25LL8YTt+LbFobqw==",
       "dependencies": {
-        "@commercetools/sdk-client": "^2.1.1",
+        "@commercetools/sdk-client-v2": "^1.0.1",
         "@commercetools/sdk-middleware-auth": "^6.0.4",
         "@commercetools/sdk-middleware-http": "^6.0.4",
         "@commercetools/sdk-middleware-logger": "^2.1.1",
@@ -677,6 +676,16 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@commercetools/sdk-client/-/sdk-client-2.1.2.tgz",
       "integrity": "sha512-YPpK39pkjfedjS1/BFg2d7CrvTeN7vIS5vfiqEkKOtAoUxiNkugv59gRSoh2Em8SOccxyM/skpgHyTqfmJzXug=="
+    },
+    "node_modules/@commercetools/sdk-client-v2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@commercetools/sdk-client-v2/-/sdk-client-v2-1.0.2.tgz",
+      "integrity": "sha512-DPd81EKTqLTAKL2W985LaXacg02VgdZ0nnSKqSXBz2ObL64WTsrccDh/OnN2qkpj1NxddMqCUX2EVz8cy363MA==",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "node-fetch": "^2.6.1",
+        "querystring": "^0.2.1"
+      }
     },
     "node_modules/@commercetools/sdk-middleware-auth": {
       "version": "6.2.0",
@@ -1634,6 +1643,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -1795,6 +1823,29 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -2378,14 +2429,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-11.0.0.tgz",
-      "integrity": "sha512-Fp/b504Y5W+e+FpCxTFMUZ7ZEQkQYF0rx+KZtmwixJxGQbLHrhCwo3FjZgNC8vIfrSi29PABNbMoCGD9YoiXbQ==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/duplexer3": {
@@ -3169,6 +3212,25 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
@@ -4582,14 +4644,22 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-fetch-commonjs": {
@@ -6522,9 +6592,9 @@
   },
   "dependencies": {
     "@azure/functions": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-1.2.3.tgz",
-      "integrity": "sha512-dZITbYPNg6ay6ngcCOjRUh1wDhlFITS0zIkqplyH5KfKEAVPooaoaye5mUFnR+WP9WdGRjlNXyl/y2tgWKHcRg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-3.0.0.tgz",
+      "integrity": "sha512-nxOdQdYoy9JEdAPsQlBWavsRvbH5qT2fpwMcY64s1sLIT8QwtW7ebh/MJNgzeAac+JaC6IED7plDiizq8oZUNw=="
     },
     "@babel/code-frame": {
       "version": "7.16.7",
@@ -6988,11 +7058,11 @@
       "integrity": "sha512-d6migEVDtJ/BlKAkpGj4HZvUSBmKwCIX6L8iRRlMNbbBLjpN3oWqOi5nRsO3v21bS8LHBBVYoFWrBtWKbqLeVQ=="
     },
     "@commercetools/platform-sdk": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@commercetools/platform-sdk/-/platform-sdk-1.20.0.tgz",
-      "integrity": "sha512-vjorTz9yZ0wh8MRgncqjeJstREIaOA2glGR/ZjmJvLNpxksE0h2FKNA+/T6K7k2YzdjnNgWE6FKh/FU1TaiGRA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@commercetools/platform-sdk/-/platform-sdk-2.1.0.tgz",
+      "integrity": "sha512-QhfTkU8tuO8buYbHmGOSZuWE7kObHlx0dZsKwCYyVJeplFThmb1ni7f1CfK7PNbPWoRO9k25LL8YTt+LbFobqw==",
       "requires": {
-        "@commercetools/sdk-client": "^2.1.1",
+        "@commercetools/sdk-client-v2": "^1.0.1",
         "@commercetools/sdk-middleware-auth": "^6.0.4",
         "@commercetools/sdk-middleware-http": "^6.0.4",
         "@commercetools/sdk-middleware-logger": "^2.1.1",
@@ -7003,6 +7073,16 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@commercetools/sdk-client/-/sdk-client-2.1.2.tgz",
       "integrity": "sha512-YPpK39pkjfedjS1/BFg2d7CrvTeN7vIS5vfiqEkKOtAoUxiNkugv59gRSoh2Em8SOccxyM/skpgHyTqfmJzXug=="
+    },
+    "@commercetools/sdk-client-v2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@commercetools/sdk-client-v2/-/sdk-client-v2-1.0.2.tgz",
+      "integrity": "sha512-DPd81EKTqLTAKL2W985LaXacg02VgdZ0nnSKqSXBz2ObL64WTsrccDh/OnN2qkpj1NxddMqCUX2EVz8cy363MA==",
+      "requires": {
+        "buffer": "^6.0.3",
+        "node-fetch": "^2.6.1",
+        "querystring": "^0.2.1"
+      }
     },
     "@commercetools/sdk-middleware-auth": {
       "version": "6.2.0",
@@ -7823,6 +7903,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -7945,6 +8030,15 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-from": {
@@ -8421,11 +8515,6 @@
       "requires": {
         "is-obj": "^2.0.0"
       }
-    },
-    "dotenv": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-11.0.0.tgz",
-      "integrity": "sha512-Fp/b504Y5W+e+FpCxTFMUZ7ZEQkQYF0rx+KZtmwixJxGQbLHrhCwo3FjZgNC8vIfrSi29PABNbMoCGD9YoiXbQ=="
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -9000,6 +9089,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore-by-default": {
       "version": "1.0.1",
@@ -10090,9 +10184,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
       },

--- a/notifications/package-lock.json
+++ b/notifications/package-lock.json
@@ -4523,14 +4523,22 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-fetch-commonjs": {
@@ -9950,9 +9958,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "requires": {
         "whatwg-url": "^5.0.0"
       },


### PR DESCRIPTION
## Description

`node-fetch` has a security advisory raised: https://github.com/advisories/GHSA-r683-j2x4-v87g

Bump the version of this dependency to a patched version. Done on notifications and extension.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

Tests pass, `npm audit` returns no warnings.

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation where necessary
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works/doesn't break everything
- [ ] Existing tests pass locally with my changes
