### PR TITLE
Fix order id bug

### DIFF
--- a/extension/src/requestHandlers/createOrder.ts
+++ b/extension/src/requestHandlers/createOrder.ts
@@ -212,13 +212,18 @@ export function createCtActions(orderResponse: Order, ctPayment: CTPayment, cart
       id: interfaceInteractionId,
       timestamp: mollieCreatedAt,
     };
+
+    // Convert the Mollie orderId to an acceptable one for CommerceTools
+    let mollieOrderId = orderResponse.id;
+    let commerceToolsOrderId = mollieOrderId.substring(0, 5) + '_' + mollieOrderId.substring(6);
+
     const result: Action[] = [
       // Add interface interaction
       makeActions.addInterfaceInteraction(interfaceInteractionParams),
       // Set status interface text
       makeActions.setStatusInterfaceText(orderResponse.status),
       // Set key
-      makeActions.setKey(orderResponse.id),
+      makeActions.setKey(commerceToolsOrderId),
       // Update transaction state
       makeActions.changeTransactionState(originalTransaction.id, CTTransactionState.Pending),
       // Update transaction interactionId

--- a/extension/tests/component/__snapshots__/createOrder.test.ts.snap
+++ b/extension/tests/component/__snapshots__/createOrder.test.ts.snap
@@ -8,7 +8,7 @@ exports[`Create Order Happy Path Should return 201 when mollie order created fro
     "createdAt": "2021-12-21T07:33:07+00:00",
     "id": "b2bd1698-9923-4704-9729-02db2de495d1",
     "request": "{"cartId":"84e5f274-c413-404e-b938-ffb45ce63f61","transactionId":"2b5f68ad-ae94-4bf1-ae41-7096e5142f89","createPayment":{}}",
-    "response": "{"mollieOrderId":"ord_ca1j7q","checkoutUrl":"https://www.mollie.com/checkout/order/ca1j7q","transactionId":"2b5f68ad-ae94-4bf1-ae41-7096e5142f89"}",
+    "response": "{"mollieOrderId":"ord_1.ca1j7q","checkoutUrl":"https://www.mollie.com/checkout/order/ca1j7q","transactionId":"2b5f68ad-ae94-4bf1-ae41-7096e5142f89"}",
   },
   "type": {
     "key": "ct-mollie-integration-interface-interaction-type",
@@ -26,7 +26,7 @@ exports[`Create Order Happy Path Should return 201 when mollie order created fro
 exports[`Create Order Happy Path Should return 201 when mollie order created from cart with both Line Items and Custom Line Items 3`] = `
 {
   "action": "setKey",
-  "key": "ord_ca1j7q",
+  "key": "ord_1_ca1j7q",
 }
 `;
 
@@ -62,7 +62,7 @@ exports[`Create Order Happy Path Should return 201 when mollie order created suc
     "createdAt": "2021-12-20T11:17:23+00:00",
     "id": "b2bd1698-9923-4704-9729-02db2de495d1",
     "request": "{"cartId":"08f21547-92c8-4519-9fd8-84dc05827f0f","transactionId":"2b5f68ad-ae94-4bf1-ae41-7096e5142f89","createPayment":{}}",
-    "response": "{"mollieOrderId":"ord_l2idwq","checkoutUrl":"https://www.mollie.com/checkout/order/l2idwq","transactionId":"2b5f68ad-ae94-4bf1-ae41-7096e5142f89"}",
+    "response": "{"mollieOrderId":"ord_1.l2idwq","checkoutUrl":"https://www.mollie.com/checkout/order/l2idwq","transactionId":"2b5f68ad-ae94-4bf1-ae41-7096e5142f89"}",
   },
   "type": {
     "key": "ct-mollie-integration-interface-interaction-type",
@@ -80,7 +80,7 @@ exports[`Create Order Happy Path Should return 201 when mollie order created suc
 exports[`Create Order Happy Path Should return 201 when mollie order created successfully using pay later method (Klarnapaylater) 3`] = `
 {
   "action": "setKey",
-  "key": "ord_l2idwq",
+  "key": "ord_1_l2idwq",
 }
 `;
 
@@ -116,7 +116,7 @@ exports[`Create Order Happy Path Should return 201 when mollie order created suc
     "createdAt": "2021-12-20T10:15:15+00:00",
     "id": "b2bd1698-9923-4704-9729-02db2de495d1",
     "request": "{"cartId":"08f21547-92c8-4519-9fd8-84dc05827f0f","transactionId":"2b5f68ad-ae94-4bf1-ae41-7096e5142f89","createPayment":{}}",
-    "response": "{"mollieOrderId":"ord_8xnw8a","checkoutUrl":"https://www.mollie.com/checkout/order/8xnw8a","transactionId":"2b5f68ad-ae94-4bf1-ae41-7096e5142f89"}",
+    "response": "{"mollieOrderId":"ord_1.8xnw8a","checkoutUrl":"https://www.mollie.com/checkout/order/8xnw8a","transactionId":"2b5f68ad-ae94-4bf1-ae41-7096e5142f89"}",
   },
   "type": {
     "key": "ct-mollie-integration-interface-interaction-type",
@@ -134,7 +134,7 @@ exports[`Create Order Happy Path Should return 201 when mollie order created suc
 exports[`Create Order Happy Path Should return 201 when mollie order created successfully using pay now method (iDEAL) 3`] = `
 {
   "action": "setKey",
-  "key": "ord_8xnw8a",
+  "key": "ord_1_8xnw8a",
 }
 `;
 

--- a/extension/tests/component/cancelOrder.test.ts
+++ b/extension/tests/component/cancelOrder.test.ts
@@ -10,7 +10,7 @@ describe('Cancel Order', () => {
   const mockLogError = jest.fn();
 
   const ctPaymentId = 'dfc2dcb0-10b8-4091-8334-687ce9db16ed';
-  const mollieOrderId = 'ord_8wmqcHMN4U';
+  const mollieOrderId = 'ord_1_8wmqcHMN4U';
   const molliePaymentId = 'tr_GrP6dJRf3U';
 
   const baseMockCTPayment: any = {

--- a/extension/tests/component/captureFunds.test.ts
+++ b/extension/tests/component/captureFunds.test.ts
@@ -9,7 +9,7 @@ import { orderAuthorized, orderShipmentSuccess, shipmentError } from './mockResp
 describe('Capture Funds', () => {
   const mockLogError = jest.fn();
   const ctPaymentId = 'dfc2dcb0-10b8-4091-8334-687ce9db16ed';
-  const mollieOrderId = 'ord_8wmqcHMN4U';
+  const mollieOrderId = 'ord_1_8wmqcHMN4U';
   const molliePaymentId = 'tr_GrP6dJRf3U';
 
   const baseMockCTPayment: any = {

--- a/extension/tests/component/createOrder.test.ts
+++ b/extension/tests/component/createOrder.test.ts
@@ -243,7 +243,7 @@ describe('Create Order', () => {
       // Ensure the interface interaction contains the checkout url
       const interfaceInteractionAction = actions.find((action: any) => action.action === 'addInterfaceInteraction');
       expect(JSON.parse(interfaceInteractionAction.fields.response)).toEqual({
-        mollieOrderId: 'ord_8xnw8a',
+        mollieOrderId: 'ord_1.8xnw8a',
         checkoutUrl: 'https://www.mollie.com/checkout/order/8xnw8a',
         transactionId: '2b5f68ad-ae94-4bf1-ae41-7096e5142f89',
       });
@@ -286,7 +286,7 @@ describe('Create Order', () => {
       // Ensure the interface interaction contains the checkout url
       const interfaceInteractionAction = actions.find((action: any) => action.action === 'addInterfaceInteraction');
       expect(JSON.parse(interfaceInteractionAction.fields.response)).toEqual({
-        mollieOrderId: 'ord_l2idwq',
+        mollieOrderId: 'ord_1.l2idwq',
         checkoutUrl: 'https://www.mollie.com/checkout/order/l2idwq',
         transactionId: '2b5f68ad-ae94-4bf1-ae41-7096e5142f89',
       });
@@ -331,7 +331,7 @@ describe('Create Order', () => {
       // Ensure the interface interaction contains the checkout url
       const interfaceInteractionAction = actions.find((action: any) => action.action === 'addInterfaceInteraction');
       expect(JSON.parse(interfaceInteractionAction.fields.response)).toEqual({
-        mollieOrderId: 'ord_ca1j7q',
+        mollieOrderId: 'ord_1.ca1j7q',
         checkoutUrl: 'https://www.mollie.com/checkout/order/ca1j7q',
         transactionId: '2b5f68ad-ae94-4bf1-ae41-7096e5142f89',
       });

--- a/extension/tests/component/mockResponses/mollieData/createOrder.data.ts
+++ b/extension/tests/component/mockResponses/mollieData/createOrder.data.ts
@@ -67,7 +67,7 @@ export const amountLowerThanMinimumKlarnaSliceIt = {
 
 export const orderCreatedWithTwoLineItemsUsingKlarna = {
   resource: 'order',
-  id: 'ord_l2idwq',
+  id: 'ord_1.l2idwq',
   profileId: 'pfl_a2jBK6dR32',
   method: 'klarnapaylater',
   amount: {
@@ -109,7 +109,7 @@ export const orderCreatedWithTwoLineItemsUsingKlarna = {
     {
       resource: 'orderline',
       id: 'odl_1.q46hg4',
-      orderId: 'ord_l2idwq',
+      orderId: 'ord_1.l2idwq',
       name: 'Sweater Pinko white',
       sku: 'M0E20000000DJR9',
       type: 'physical',
@@ -155,7 +155,7 @@ export const orderCreatedWithTwoLineItemsUsingKlarna = {
     {
       resource: 'orderline',
       id: 'odl_1.wb6ssm',
-      orderId: 'ord_l2idwq',
+      orderId: 'ord_1.l2idwq',
       name: 'Bag medium GUM black',
       sku: 'A0E2000000027DV',
       type: 'physical',
@@ -222,7 +222,7 @@ export const orderCreatedWithTwoLineItemsUsingKlarna = {
         },
         locale: 'nl_NL',
         profileId: 'pfl_a2jBK6dR32',
-        orderId: 'ord_l2idwq',
+        orderId: 'ord_1.l2idwq',
         sequenceType: 'oneoff',
         redirectUrl: 'https://www.redirect.url/',
         webhookUrl: 'https://www.webhook.url',
@@ -244,7 +244,7 @@ export const orderCreatedWithTwoLineItemsUsingKlarna = {
             type: 'text/html',
           },
           order: {
-            href: 'https://api.mollie.com/v2/orders/ord_l2idwq',
+            href: 'https://api.mollie.com/v2/orders/ord_1.l2idwq',
             type: 'application/hal+json',
           },
         },
@@ -254,11 +254,11 @@ export const orderCreatedWithTwoLineItemsUsingKlarna = {
   },
   _links: {
     self: {
-      href: 'https://api.mollie.com/v2/orders/ord_l2idwq?embed=payments%2Crefunds',
+      href: 'https://api.mollie.com/v2/orders/ord_1.l2idwq?embed=payments%2Crefunds',
       type: 'application/hal+json',
     },
     dashboard: {
-      href: 'https://www.mollie.com/dashboard/org_12908718/orders/ord_l2idwq',
+      href: 'https://www.mollie.com/dashboard/org_12908718/orders/ord_1.l2idwq',
       type: 'text/html',
     },
     checkout: {
@@ -274,7 +274,7 @@ export const orderCreatedWithTwoLineItemsUsingKlarna = {
 
 export const orderCreatedWithTwoLinesUsingIdeal = {
   resource: 'order',
-  id: 'ord_8xnw8a',
+  id: 'ord_1.8xnw8a',
   profileId: 'pfl_a2jBK6dR32',
   method: 'ideal',
   amount: {
@@ -316,7 +316,7 @@ export const orderCreatedWithTwoLinesUsingIdeal = {
     {
       resource: 'orderline',
       id: 'odl_1.y0kpfo',
-      orderId: 'ord_8xnw8a',
+      orderId: 'ord_1.8xnw8a',
       name: 'Sweater Pinko white',
       sku: 'M0E20000000DJR9',
       type: 'physical',
@@ -362,7 +362,7 @@ export const orderCreatedWithTwoLinesUsingIdeal = {
     {
       resource: 'orderline',
       id: 'odl_1.4labw6',
-      orderId: 'ord_8xnw8a',
+      orderId: 'ord_1.8xnw8a',
       name: 'Bag medium GUM black',
       sku: 'A0E2000000027DV',
       type: 'physical',
@@ -425,7 +425,7 @@ export const orderCreatedWithTwoLinesUsingIdeal = {
         expiresAt: '2021-12-20T10:30:15+00:00',
         locale: 'nl_NL',
         profileId: 'pfl_a2jBK6dR32',
-        orderId: 'ord_8xnw8a',
+        orderId: 'ord_1.8xnw8a',
         sequenceType: 'oneoff',
         redirectUrl: 'https://www.redirect.url/',
         webhookUrl: 'https://www.webhook.url',
@@ -443,7 +443,7 @@ export const orderCreatedWithTwoLinesUsingIdeal = {
             type: 'text/html',
           },
           order: {
-            href: 'https://api.mollie.com/v2/orders/ord_8xnw8a',
+            href: 'https://api.mollie.com/v2/orders/ord_1.8xnw8a',
             type: 'application/hal+json',
           },
         },
@@ -453,11 +453,11 @@ export const orderCreatedWithTwoLinesUsingIdeal = {
   },
   _links: {
     self: {
-      href: 'https://api.mollie.com/v2/orders/ord_8xnw8a?embed=payments%2Crefunds',
+      href: 'https://api.mollie.com/v2/orders/ord_1.8xnw8a?embed=payments%2Crefunds',
       type: 'application/hal+json',
     },
     dashboard: {
-      href: 'https://www.mollie.com/dashboard/org_12908718/orders/ord_8xnw8a',
+      href: 'https://www.mollie.com/dashboard/org_12908718/orders/ord_1.8xnw8a',
       type: 'text/html',
     },
     checkout: {
@@ -473,7 +473,7 @@ export const orderCreatedWithTwoLinesUsingIdeal = {
 
 export const orderCreatedIncludingDiscountLineUsingIdeal = {
   resource: 'order',
-  id: 'ord_ca1j7q',
+  id: 'ord_1.ca1j7q',
   profileId: 'pfl_a2jBK6dR32',
   method: 'ideal',
   amount: {
@@ -515,7 +515,7 @@ export const orderCreatedIncludingDiscountLineUsingIdeal = {
     {
       resource: 'orderline',
       id: 'odl_1.uvuwbi',
-      orderId: 'ord_ca1j7q',
+      orderId: 'ord_1.ca1j7q',
       name: 'Sweater Pinko white',
       sku: 'M0E20000000DJR9',
       type: 'physical',
@@ -561,7 +561,7 @@ export const orderCreatedIncludingDiscountLineUsingIdeal = {
     {
       resource: 'orderline',
       id: 'odl_1.1uasgg',
-      orderId: 'ord_ca1j7q',
+      orderId: 'ord_1.ca1j7q',
       name: 'Bag medium GUM black',
       sku: 'A0E2000000027DV',
       type: 'physical',
@@ -607,7 +607,7 @@ export const orderCreatedIncludingDiscountLineUsingIdeal = {
     {
       resource: 'orderline',
       id: 'odl_1.7xk3r6',
-      orderId: 'ord_ca1j7q',
+      orderId: 'ord_1.ca1j7q',
       name: 'Holiday Discount',
       sku: null,
       type: 'physical',
@@ -670,7 +670,7 @@ export const orderCreatedIncludingDiscountLineUsingIdeal = {
         expiresAt: '2021-12-21T07:48:07+00:00',
         locale: 'nl_NL',
         profileId: 'pfl_a2jBK6dR32',
-        orderId: 'ord_ca1j7q',
+        orderId: 'ord_1.ca1j7q',
         sequenceType: 'oneoff',
         redirectUrl: 'https://google.com',
         webhookUrl: 'https://google.com',
@@ -688,7 +688,7 @@ export const orderCreatedIncludingDiscountLineUsingIdeal = {
             type: 'text/html',
           },
           order: {
-            href: 'https://api.mollie.com/v2/orders/ord_ca1j7q',
+            href: 'https://api.mollie.com/v2/orders/ord_1.ca1j7q',
             type: 'application/hal+json',
           },
         },
@@ -698,11 +698,11 @@ export const orderCreatedIncludingDiscountLineUsingIdeal = {
   },
   _links: {
     self: {
-      href: 'https://api.mollie.com/v2/orders/ord_ca1j7q?embed=payments%2Crefunds',
+      href: 'https://api.mollie.com/v2/orders/ord_1.ca1j7q?embed=payments%2Crefunds',
       type: 'application/hal+json',
     },
     dashboard: {
-      href: 'https://www.mollie.com/dashboard/org_12908718/orders/ord_ca1j7q',
+      href: 'https://www.mollie.com/dashboard/org_12908718/orders/ord_1.ca1j7q',
       type: 'text/html',
     },
     checkout: {

--- a/extension/tests/unit/requestHandlers/__snapshots__/createOrder.test.ts.snap
+++ b/extension/tests/unit/requestHandlers/__snapshots__/createOrder.test.ts.snap
@@ -8,7 +8,7 @@ exports[`createCTActions Should create correct ct actions from request and molli
     "createdAt": "2018-08-02T09:29:56+00:00",
     "id": "3fea7470-5434-4056-a829-a187339e94d8",
     "request": "{"cartId":"fd5317fa-c2f8-44c0-85ab-a1c1169d2404","transactionId":"949ab89f-7a71-4c7a-bb43-605354322a96","createPayment":{"locale":"fr_FR"}}",
-    "response": "{"mollieOrderId":"ord_dsczl7","transactionId":"949ab89f-7a71-4c7a-bb43-605354322a96"}",
+    "response": "{"mollieOrderId":"ord_1.dsczl7","transactionId":"949ab89f-7a71-4c7a-bb43-605354322a96"}",
   },
   "type": {
     "key": "ct-mollie-integration-interface-interaction-type",
@@ -26,7 +26,7 @@ exports[`createCTActions Should create correct ct actions from request and molli
 exports[`createCTActions Should create correct ct actions from request and mollies order 3`] = `
 {
   "action": "setKey",
-  "key": "ord_dsczl7",
+  "key": "ord_1_dsczl7",
 }
 `;
 

--- a/extension/tests/unit/requestHandlers/createOrder.test.ts
+++ b/extension/tests/unit/requestHandlers/createOrder.test.ts
@@ -271,7 +271,7 @@ describe('createCTActions', () => {
     };
     const mockedMollieCreatedOrder = {
       resource: 'order',
-      id: 'ord_dsczl7',
+      id: 'ord_1.dsczl7',
       profileId: 'pfl_VtWA783A63',
       createdAt: '2018-08-02T09:29:56+00:00',
       amount: { value: '10.00', currency: 'EUR' },
@@ -304,7 +304,7 @@ describe('createCTActions', () => {
     };
     const mockedMollieCreatedOrder: any = {
       resource: 'order',
-      id: 'ord_dsczl7',
+      id: 'ord_1.dsczl7',
       profileId: 'pfl_VtWA783A63',
       amount: { value: '10.00', currency: 'EUR' },
       orderNumber: '1001',
@@ -327,7 +327,7 @@ describe('createCTActions', () => {
     };
     const mockedMollieCreatedOrder: any = {
       resource: 'order',
-      id: 'ord_dsczl7',
+      id: 'ord_1.dsczl7',
       profileId: 'pfl_VtWA783A63',
       amount: { value: '10.00', currency: 'EUR' },
       orderNumber: '1001',


### PR DESCRIPTION
## Description

### Changes orderId from Mollie to CommerceTools for the new Mollie formatts

Mollie orderId format changed from 
ord_12345678ABCD 
to 
ord_1.12345678ABCD
and CommerceTools field for orderId can't accept '.' because the format is
^[A-Za-z0-9_-]+$
We need to replace the '.' with '_' as a local patch

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

Executed all the standard tests and updated to match the new orderId format
Executed manually the complete flow in pre production test environment

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation where necessary
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works/doesn't break everything
- [X] Existing tests pass locally with my changes
