### PR TITLE
Store mollie order in customer field

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,7 @@ The notification module will process the notification sent by Mollie and match t
 Please see the [Contribution Guide](./docs/ContributionGuidelines.md).
 
 ## Support & other guides
+
+[CommerceTools integration Wiki](https://github.com/mollie/commercetools/wiki)
+
 [Mollie's support page](https://help.mollie.com/hc/en-us)

--- a/extension/config/config.ts
+++ b/extension/config/config.ts
@@ -17,7 +17,6 @@ const isConfigValid = (config: Config): { valid: boolean; message: string } => {
 };
 
 export function loadConfig(ctMollieConfig: string | undefined) {
-  console.info('loadConfig : ' + ctMollieConfig);
   try {
     const envConfig = JSON.parse(ctMollieConfig || '');
 

--- a/extension/custom-types.json
+++ b/extension/custom-types.json
@@ -38,6 +38,17 @@
         },
         "required": false,
         "inputHint": "MultiLine"
+      },
+      {
+        "type": {
+          "name": "String"
+        },
+        "name": "mollieOrderId",
+        "label": {
+          "en": "Original Mollie OrderId"
+        },
+        "required": false,
+        "inputHint": "SingleLine"
       }
     ]
   },

--- a/extension/src/requestHandlers/createOrder.ts
+++ b/extension/src/requestHandlers/createOrder.ts
@@ -230,6 +230,8 @@ export function createCtActions(orderResponse: Order, ctPayment: CTPayment, cart
       makeActions.changeTransactionInteractionId(originalTransaction.id, molliePaymentId),
       // Update transaction timestamp
       makeActions.changeTransactionTimestamp(originalTransaction.id, mollieCreatedAt),
+      // Store the original Mollie OrderId in custom field
+      makeActions.setCustomField('mollieOrderId', mollieOrderId),
     ];
     return Promise.resolve(result);
   } catch (error: any) {

--- a/extension/tests/component/__snapshots__/createOrder.test.ts.snap
+++ b/extension/tests/component/__snapshots__/createOrder.test.ts.snap
@@ -54,6 +54,14 @@ exports[`Create Order Happy Path Should return 201 when mollie order created fro
 }
 `;
 
+exports[`Create Order Happy Path Should return 201 when mollie order created from cart with both Line Items and Custom Line Items 7`] = `
+{
+  "action": "setCustomField",
+  "name": "mollieOrderId",
+  "value": "ord_1.ca1j7q",
+}
+`;
+
 exports[`Create Order Happy Path Should return 201 when mollie order created successfully using pay later method (Klarnapaylater) 1`] = `
 {
   "action": "addInterfaceInteraction",
@@ -108,6 +116,14 @@ exports[`Create Order Happy Path Should return 201 when mollie order created suc
 }
 `;
 
+exports[`Create Order Happy Path Should return 201 when mollie order created successfully using pay later method (Klarnapaylater) 7`] = `
+{
+  "action": "setCustomField",
+  "name": "mollieOrderId",
+  "value": "ord_1.l2idwq",
+}
+`;
+
 exports[`Create Order Happy Path Should return 201 when mollie order created successfully using pay now method (iDEAL) 1`] = `
 {
   "action": "addInterfaceInteraction",
@@ -159,5 +175,13 @@ exports[`Create Order Happy Path Should return 201 when mollie order created suc
   "action": "changeTransactionTimestamp",
   "timestamp": "2021-12-20T10:15:15+00:00",
   "transactionId": "2b5f68ad-ae94-4bf1-ae41-7096e5142f89",
+}
+`;
+
+exports[`Create Order Happy Path Should return 201 when mollie order created successfully using pay now method (iDEAL) 7`] = `
+{
+  "action": "setCustomField",
+  "name": "mollieOrderId",
+  "value": "ord_1.8xnw8a",
 }
 `;

--- a/extension/tests/component/createOrder.test.ts
+++ b/extension/tests/component/createOrder.test.ts
@@ -238,7 +238,7 @@ describe('Create Order', () => {
       expect(status).toBe(201);
 
       const { actions } = body;
-      expect(actions).toHaveLength(6);
+      expect(actions).toHaveLength(7);
 
       // Ensure the interface interaction contains the checkout url
       const interfaceInteractionAction = actions.find((action: any) => action.action === 'addInterfaceInteraction');
@@ -281,7 +281,7 @@ describe('Create Order', () => {
       expect(status).toBe(201);
 
       const { actions } = body;
-      expect(actions).toHaveLength(6);
+      expect(actions).toHaveLength(7);
 
       // Ensure the interface interaction contains the checkout url
       const interfaceInteractionAction = actions.find((action: any) => action.action === 'addInterfaceInteraction');
@@ -326,7 +326,7 @@ describe('Create Order', () => {
       expect(status).toBe(201);
 
       const { actions } = body;
-      expect(actions).toHaveLength(6);
+      expect(actions).toHaveLength(7);
 
       // Ensure the interface interaction contains the checkout url
       const interfaceInteractionAction = actions.find((action: any) => action.action === 'addInterfaceInteraction');

--- a/extension/tests/unit/requestHandlers/__snapshots__/createOrder.test.ts.snap
+++ b/extension/tests/unit/requestHandlers/__snapshots__/createOrder.test.ts.snap
@@ -54,6 +54,14 @@ exports[`createCTActions Should create correct ct actions from request and molli
 }
 `;
 
+exports[`createCTActions Should create correct ct actions from request and mollies order 7`] = `
+{
+  "action": "setCustomField",
+  "name": "mollieOrderId",
+  "value": "ord_1.dsczl7",
+}
+`;
+
 exports[`makeMollieAddress Should properly map address fields 1`] = `
 {
   "city": "Amsterdam",

--- a/extension/tests/unit/requestHandlers/createOrder.test.ts
+++ b/extension/tests/unit/requestHandlers/createOrder.test.ts
@@ -289,7 +289,7 @@ describe('createCTActions', () => {
       },
     } as Order;
     const ctActions = await createCtActions(mockedMollieCreatedOrder, mockedCtObject as CTPayment, 'fd5317fa-c2f8-44c0-85ab-a1c1169d2404');
-    expect(ctActions).toHaveLength(6);
+    expect(ctActions).toHaveLength(7);
     ctActions.forEach(action => {
       expect(action).toMatchSnapshot();
     });


### PR DESCRIPTION
## Description

Store Mollie OrderId with the original format in customer type field, so that the original value is not missed and can be used in integrations between CommerceTools, Mollie and other tools

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

Executed and updated all the existing tests
Executed manually a full flow in pre production environment

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation where necessary
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works/doesn't break everything
- [X] Existing tests pass locally with my changes
