### PR TITLE
No order with token error

### DIFF
--- a/extension/lambdaHandler.ts
+++ b/extension/lambdaHandler.ts
@@ -2,21 +2,28 @@ import { APIGatewayProxyEvent } from 'aws-lambda';
 import { createCorrelationId } from './src/utils';
 import handleRequest from './src/requestHandlers/handleRequest';
 import { HandleRequestInput, HandleRequestSuccess, Action } from './src/types';
+import Logger from './src/logger/logger';
 
 exports.handler = async (event: APIGatewayProxyEvent) => {
   const body = event.body ? JSON.parse(event.body) : event;
 
   const headers = new Map([['authorization', event.headers?.['authorization'] ?? '']]);
   const input = new HandleRequestInput(event.path, event.httpMethod, body, headers);
+  Logger.debug('LambdaHandler : event.path : ' + event.path);
+  Logger.debug('LambdaHandler : input : ' + JSON.stringify(body));
 
   let result = await handleRequest(input);
 
   if (result instanceof HandleRequestSuccess) {
+    Logger.debug('LambdaHandler : Success - ' + result.status);
+    Logger.debug('Result : ' + JSON.stringify(result));
     return {
       responseType: 'UpdateRequest',
       actions: result.actions,
     };
   } else {
+    Logger.debug('LambdaHandler : Error handling request - ' + result.status);
+    Logger.debug('Errors : ' + JSON.stringify(result.errors));
     return {
       headers: { ...event.headers, 'x-correlation-id': event.headers?.['x-correlation-id'] ?? createCorrelationId() },
       statusCode: result.status,

--- a/extension/src/requestHandlers/cancelOrder.ts
+++ b/extension/src/requestHandlers/cancelOrder.ts
@@ -5,12 +5,18 @@ import formatErrorResponse from '../errorHandlers';
 import { Action, ControllerAction, CTPayment, CTTransactionState, CTTransactionType, CTUpdatesRequestedResponse } from '../types';
 import { isPartialTransaction, findInitialTransaction, ctToMollieLines, mollieToCtLines } from '../utils';
 import { makeActions } from '../makeActions';
+import { ctToMollieOrderId } from '../utils';
 
 export function getCancelOrderParams(ctPayment: Required<CTPayment>, mollieOrder: Order | undefined): Promise<OrderLineCancelParams> {
+  Logger.debug('getCancelOrderParams : ctPayment : ' + JSON.stringify(ctPayment));
+  Logger.debug('getCancelOrderParams : mollieOrder : ' + JSON.stringify(mollieOrder));
   try {
     const initialCancelAuthorization = findInitialTransaction(ctPayment.transactions, CTTransactionType.CancelAuthorization);
+
+    let mollieOrderId = ctToMollieOrderId(ctPayment.key);
+
     const cancelOrderParams = {
-      orderId: ctPayment.key,
+      orderId: mollieOrderId,
       lines: ctToMollieLines(initialCancelAuthorization!, mollieOrder!.lines),
     };
 
@@ -48,11 +54,14 @@ export function createCtActions(mollieCancelOrderRes: Order | boolean, ctPayment
 }
 
 export default async function cancelOrder(ctPayment: Required<CTPayment>, mollieClient: MollieClient, getCancelOrderParams: Function, createCtActions: Function): Promise<CTUpdatesRequestedResponse> {
+  Logger.debug('cancelOrder : ctPayment : ' + JSON.stringify(ctPayment));
   try {
-    const mollieOrderRes = isPartialTransaction(ctPayment.transactions ?? [], CTTransactionType.CancelAuthorization) ? await mollieClient.orders.get(ctPayment.key) : undefined;
+    let mollieOrderId = ctToMollieOrderId(ctPayment.key);
+
+    const mollieOrderRes = isPartialTransaction(ctPayment.transactions ?? [], CTTransactionType.CancelAuthorization) ? await mollieClient.orders.get(mollieOrderId) : undefined;
     const cancelOrderParams = mollieOrderRes ? await getCancelOrderParams(ctPayment, mollieOrderRes) : undefined;
     Logger.debug('cancelOrderParams: %o', cancelOrderParams);
-    const mollieCancelOrderRes = cancelOrderParams ? await mollieClient.orders_lines.cancel(cancelOrderParams) : await mollieClient.orders.cancel(ctPayment.key);
+    const mollieCancelOrderRes = cancelOrderParams ? await mollieClient.orders_lines.cancel(cancelOrderParams) : await mollieClient.orders.cancel(mollieOrderId);
     Logger.debug('mollieCancelOrderRes: %o', mollieCancelOrderRes);
     const ctActions = createCtActions(mollieCancelOrderRes, ctPayment);
     return {

--- a/extension/src/requestHandlers/createCustomRefund.ts
+++ b/extension/src/requestHandlers/createCustomRefund.ts
@@ -97,6 +97,7 @@ const createCtActions = (refundTransaction: CTTransaction, originalPaymentTransa
  * get the mollie payment id.
  */
 export async function createCustomRefund(ctPayment: CTPayment, mollieClient: MollieClient): Promise<CTUpdatesRequestedResponse> {
+  Logger.debug('createCustomRefund : ctPayment : ' + JSON.stringify(ctPayment));
   try {
     // Get the refund transaction (initial), amount etc.
     const { transactions } = ctPayment;

--- a/extension/src/requestHandlers/createOrder.ts
+++ b/extension/src/requestHandlers/createOrder.ts
@@ -7,6 +7,7 @@ import { makeMollieAmount } from '../utils';
 import Logger from '../logger/logger';
 import config from '../../config/config';
 import { makeActions } from '../makeActions';
+import { mollieToCtOrderId } from '../utils';
 
 const {
   commercetools: { projectKey },
@@ -215,10 +216,7 @@ export function createCtActions(orderResponse: Order, ctPayment: CTPayment, cart
 
     // Convert the Mollie orderId to an acceptable one for CommerceTools
     let mollieOrderId = orderResponse.id;
-    let commerceToolsOrderId = mollieOrderId;
-    if (mollieOrderId.substring(5, 6) == '.') {
-      commerceToolsOrderId = mollieOrderId.substring(0, 5) + '_' + mollieOrderId.substring(6);
-    }
+    let commerceToolsOrderId = mollieToCtOrderId(mollieOrderId);
 
     const result: Action[] = [
       // Add interface interaction
@@ -250,6 +248,7 @@ export default async function createOrder(
   createCtActions: Function,
 ): Promise<CTUpdatesRequestedResponse> {
   const paymentId = ctPayment?.id;
+  Logger.debug('createOrder : paymentId : ' + JSON.stringify(paymentId));
   try {
     const baseRequestParams = {
       method: 'GET',

--- a/extension/src/requestHandlers/getPaymentMethods.ts
+++ b/extension/src/requestHandlers/getPaymentMethods.ts
@@ -38,6 +38,7 @@ function extractMethodListParameters(ctObj: CTPayment): Promise<MethodsListParam
 }
 
 export default async function getPaymentMethods(ctObj: CTPayment, mollieClient: MollieClient): Promise<CTUpdatesRequestedResponse> {
+  Logger.debug('getPaymentMethods : ctObj : ' + JSON.stringify(ctObj));
   try {
     const mollieOptions = await extractMethodListParameters(ctObj);
     const methods: List<Method> = await mollieClient.methods.list(mollieOptions);

--- a/extension/src/requestHandlers/handleRequest.ts
+++ b/extension/src/requestHandlers/handleRequest.ts
@@ -15,6 +15,7 @@ const commercetoolsClient = initialiseCommercetoolsClient();
 const mollieClient = initialiseMollieClient();
 
 export default async function handleRequest(input: HandleRequestInput): Promise<HandleRequestOutput> {
+  Logger.debug('handleRequest : input : ' + JSON.stringify(input));
   const { isValid, message } = checkAuthorizationHeader(input.headers);
   if (!isValid) {
     Logger.error(message);
@@ -68,6 +69,7 @@ export default async function handleRequest(input: HandleRequestInput): Promise<
 
 const processAction = async function (action: ControllerAction, ctPaymentObject: any, mollieClient: MollieClient, commercetoolsClient: any) {
   let result = {} as CTUpdatesRequestedResponse;
+  Logger.debug('processAction : action : ' + JSON.stringify(action));
   switch (action) {
     case ControllerAction.GetPaymentMethods:
       Logger.debug(`action: ${ControllerAction.GetPaymentMethods}`);

--- a/extension/src/utils.ts
+++ b/extension/src/utils.ts
@@ -113,3 +113,19 @@ export function mollieToCtLines(mollieOrderLines: OrderLine[]): string {
 
   return ctLinesString;
 }
+
+export function mollieToCtOrderId(mollieOrderId: string): string {
+  let commerceToolsOrderId = mollieOrderId;
+  if (mollieOrderId.substring(5, 6) == '.') {
+    commerceToolsOrderId = mollieOrderId.substring(0, 5) + '_' + mollieOrderId.substring(6);
+  }
+  return commerceToolsOrderId;
+}
+
+export function ctToMollieOrderId(commerceToolsOrderId: any): string {
+  let mollieOrderId = commerceToolsOrderId;
+  if (mollieOrderId != null && mollieOrderId.length > 6 && mollieOrderId.substring(5, 6) == '_') {
+    mollieOrderId = mollieOrderId.substring(0, 5) + '.' + mollieOrderId.substring(6);
+  }
+  return mollieOrderId;
+}

--- a/extension/tests/component/cancelOrder.test.ts
+++ b/extension/tests/component/cancelOrder.test.ts
@@ -10,7 +10,7 @@ describe('Cancel Order', () => {
   const mockLogError = jest.fn();
 
   const ctPaymentId = 'dfc2dcb0-10b8-4091-8334-687ce9db16ed';
-  const mollieOrderId = 'ord_1_8wmqcHMN4U';
+  const mollieOrderId = 'ord_1.8wmqcHMN4U';
   const molliePaymentId = 'tr_GrP6dJRf3U';
 
   const baseMockCTPayment: any = {

--- a/extension/tests/component/captureFunds.test.ts
+++ b/extension/tests/component/captureFunds.test.ts
@@ -9,7 +9,7 @@ import { orderAuthorized, orderShipmentSuccess, shipmentError } from './mockResp
 describe('Capture Funds', () => {
   const mockLogError = jest.fn();
   const ctPaymentId = 'dfc2dcb0-10b8-4091-8334-687ce9db16ed';
-  const mollieOrderId = 'ord_1_8wmqcHMN4U';
+  const mollieOrderId = 'ord_1.8wmqcHMN4U';
   const molliePaymentId = 'tr_GrP6dJRf3U';
 
   const baseMockCTPayment: any = {

--- a/extension/tests/unit/requestHandlers/cancelOrder.test.ts
+++ b/extension/tests/unit/requestHandlers/cancelOrder.test.ts
@@ -2,7 +2,7 @@ import { v4 as uuid } from 'uuid';
 import { Order } from '@mollie/api-client';
 import { Action, CTPayment, CTTransaction } from '../../../src/types';
 import cancelOrder, { getCancelOrderParams, createCtActions } from '../../../src/requestHandlers/cancelOrder';
-import { isPartialTransaction, createDateNowString, mollieToCtLines, findInitialTransaction, ctToMollieLines } from '../../../src/utils';
+import { isPartialTransaction, createDateNowString, mollieToCtLines, findInitialTransaction, ctToMollieLines, ctToMollieOrderId } from '../../../src/utils';
 import Logger from '../../../src/logger/logger';
 
 jest.mock('uuid');
@@ -30,6 +30,7 @@ describe('getCancelOrderParams', () => {
     const mockMollieLines = [{ id: 'odl_1.tlaa3w' }, { id: 'odl_1.6997yo' }, { id: 'odl_1.cgark2' }];
     jest.mocked(findInitialTransaction).mockReturnValue(mockTransaction);
     jest.mocked(ctToMollieLines).mockReturnValue(mockMollieLines);
+    jest.mocked(ctToMollieOrderId).mockReturnValue('ord_3uwvfd');
     const mockCtPayment = {
       key: 'ord_3uwvfd',
       transactions: [mockTransaction],
@@ -75,6 +76,7 @@ describe('getCancelOrderParams', () => {
       orderId: 'ord_3uwvfd',
       lines: mockMollieLines,
     };
+
     await expect(getCancelOrderParams(mockCtPayment, mockOrderRes)).resolves.toEqual(expectedCancelOrderParams);
   });
   it('Should create all optional params for mollie cancelOrder call when cancelling partial lines', async () => {
@@ -91,6 +93,7 @@ describe('getCancelOrderParams', () => {
     const mockMollieLines = [{ id: 'odl_1.tlaa3w', quantity: 2, amount: { value: '5.00', currency: 'EUR' } }, { id: 'odl_1.cgark2' }];
     jest.mocked(findInitialTransaction).mockReturnValue(mockTransaction);
     jest.mocked(ctToMollieLines).mockReturnValue(mockMollieLines);
+    jest.mocked(ctToMollieOrderId).mockReturnValue('ord_3uwvfd');
 
     const mockCtPayment = {
       key: 'ord_3uwvfd',
@@ -213,6 +216,7 @@ describe('cancelOrder', () => {
   });
   it('Should call mollie, handle response and return actions when cancelling complete order', async () => {
     jest.mocked(isPartialTransaction).mockReturnValue(false);
+    jest.mocked(ctToMollieOrderId).mockReturnValue('ord_jwtj05');
     const mockedCtPayment: any = {
       key: 'ord_jwtj05',
     };

--- a/extension/tests/unit/requestHandlers/createOrder.test.ts
+++ b/extension/tests/unit/requestHandlers/createOrder.test.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid } from 'uuid';
 import { Order, OrderLineType } from '@mollie/api-client';
 import { cloneDeep, omit } from 'lodash';
-import { makeMollieAmount } from '../../../src/utils';
+import { makeMollieAmount, mollieToCtOrderId } from '../../../src/utils';
 import Logger from '../../../src/logger/logger';
 import createOrder, {
   makeMollieAddress,
@@ -252,6 +252,7 @@ describe('createCTActions', () => {
   });
 
   it('Should create correct ct actions from request and mollies order', async () => {
+    jest.mocked(mollieToCtOrderId).mockReturnValue('ord_1_dsczl7');
     const mockedCreateOrderString = '{"locale":"fr_FR"}';
     const mockedCtObject = {
       id: '3d0ede94-df76-423f-b560-71d4c365d086',


### PR DESCRIPTION
## Description

Adds mollieToCtOrderId and ctToMollieOrderId functions to fix the "No order with token" error

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes)

## Testing

Executed all the test suites locally
Not able to reproduce the original bug, submitting this PR for the custom to test in its environment

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have updated the documentation where necessary
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works/doesn't break everything
- [X] Existing tests pass locally with my changes
